### PR TITLE
Added support for object method calls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+coverage/
+.nyc_output/

--- a/index.js
+++ b/index.js
@@ -82,7 +82,7 @@ function evaluate ( node, context ) {
       }
 
     case 'ThisExpression':
-      return context.this;
+      return this;
 
     case 'UnaryExpression':
       return unops[ node.operator ]( evaluate( node.argument, context ) );

--- a/index.js
+++ b/index.js
@@ -6,52 +6,91 @@ var jsep = require('jsep');
  */
 
 var binops = {
-  '||': function (a, b) { return a || b; },
-  '&&': function (a, b) { return a && b; },
-  '|': function (a, b) { return a | b; },
-  '^': function (a, b) { return a ^ b; },
-  '&': function (a, b) { return a & b; },
-  '==': function (a, b) { return a == b; }, // jshint ignore:line
-  '!=': function (a, b) { return a != b; }, // jshint ignore:line
+  '||':  function (a, b) { return a || b; },
+  '&&':  function (a, b) { return a && b; },
+  '|':   function (a, b) { return a | b; },
+  '^':   function (a, b) { return a ^ b; },
+  '&':   function (a, b) { return a & b; },
+  '==':  function (a, b) { return a == b; }, // jshint ignore:line
+  '!=':  function (a, b) { return a != b; }, // jshint ignore:line
   '===': function (a, b) { return a === b; },
   '!==': function (a, b) { return a !== b; },
-  '<': function (a, b) { return a < b; },
-  '>': function (a, b) { return a > b; },
-  '<=': function (a, b) { return a <= b; },
-  '>=': function (a, b) { return a >= b; },
-  '<<': function (a, b) { return a << b; },
-  '>>': function (a, b) { return a >> b; },
+  '<':   function (a, b) { return a < b; },
+  '>':   function (a, b) { return a > b; },
+  '<=':  function (a, b) { return a <= b; },
+  '>=':  function (a, b) { return a >= b; },
+  '<<':  function (a, b) { return a << b; },
+  '>>':  function (a, b) { return a >> b; },
   '>>>': function (a, b) { return a >>> b; },
-  '+': function (a, b) { return a + b; },
-  '-': function (a, b) { return a - b; },
-  '*': function (a, b) { return a * b; },
-  '/': function (a, b) { return a / b; },
-  '%': function (a, b) { return a % b; }
+  '+':   function (a, b) { return a + b; },
+  '-':   function (a, b) { return a - b; },
+  '*':   function (a, b) { return a * b; },
+  '/':   function (a, b) { return a / b; },
+  '%':   function (a, b) { return a % b; }
 };
 
 var unops = {
-  '-' : function(a) { return -a; },
-  '+' : function(a) { return a; },
-  '~' : function(a) { return ~a; },
-  '!' : function(a) { return !a; },
+  '-' :  function (a) { return -a; },
+  '+' :  function (a) { return a; },
+  '~' :  function (a) { return ~a; },
+  '!' :  function (a) { return !a; },
 };
 
-function evaluate (node, context) {
-  if(node.type === 'BinaryExpression') {
-    return binops[node.operator](evaluate(node.left, context), evaluate(node.right, context));
-  } else if(node.type === 'UnaryExpression') {
-    return unops[node.operator](evaluate(node.argument, context));
-  } else if (node.type === 'MemberExpression') {
-    if (node.computed) {
-      return evaluate(node.object, context)[evaluate(node.property, context)];
-    } else {
-      return evaluate(node.object, context)[node.property.name];
-    }
-  } else if (node.type === 'Identifier') {
-    return context[node.name];
-  } else if(node.type === 'Literal') {
-    return node.value;
+function evaluate_array( list, context ) {
+  return list.map( function(v,i,a) { return evaluate( v, context ); } );
+}
+
+function evaluate ( node, context ) {
+  
+  switch ( node.type ) {
+    
+    case 'ArrayExpression': 
+      return evaluate_array( node.elements, context );
+    
+    case 'BinaryExpression':
+      return binops[ node.operator ]( evaluate( node.left, context ), evaluate( node.right, context ) );
+
+    case 'CallExpression':
+      let fn = evaluate( node.callee, context );
+      if ( typeof( fn ) === "function" ) {
+        return fn.apply( null, evaluate_array( node.arguments, context ) );
+      } else {
+        return undefined;
+      }
+  
+    case 'ConditionalExpression':
+      if ( evaluate( node.test, context ) ) {
+        return evaluate( node.consequent, context );
+      } else {
+        return evaluate( node.alternate, context );
+      }
+
+    case 'Identifier':
+      return context[ node.name ];
+
+    case 'Literal':
+      return node.value;
+
+    case 'LogicalExpression':
+      return binops[ node.operator ]( evaluate( node.left, context ), evaluate( node.right, context ) );
+  
+    case 'MemberExpression':
+      if ( node.computed ) {
+        return evaluate(node.object, context)[evaluate(node.property, context)];
+      } else {
+        return evaluate(node.object, context)[node.property.name];
+      }
+
+    case 'ThisExpression':
+      return context.this;
+
+    case 'UnaryExpression':
+      return unops[ node.operator ]( evaluate( node.argument, context ) );
+
+    default:
+      return undefined;
   }
+
 }
 
 function compile (expression) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "expression-eval",
+  "version": "1.0.1",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "jsep": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/jsep/-/jsep-0.3.2.tgz",
+      "integrity": "sha512-b/QP7Apx3EEvFk5/O+bp8BmMP97EypcxqTXWs8nK+Mr9DKhxLX/EWlxERtCZ7mwWIssnOLGCGMoJ08oMiwrjIw=="
+    }
+  }
+}

--- a/test.js
+++ b/test.js
@@ -32,6 +32,7 @@ const fixtures = [
   // call expression
   {expr: 'func(5)',   expected: 6},               
   {expr: 'func(1+2)', expected: 4},
+  {expr: 'one(two)',  expected: undefined},
 
   // conditional expression
   {expr: '(true ? "true" : "false")',               expected: "true"  }, 
@@ -51,7 +52,7 @@ const fixtures = [
   {expr: 'true',  expected: true  }, // boolean literal
 
   // logical expression
-  {expr: 'true || false',   expected: true  },
+  {expr: 'false || true',   expected: true  },
   {expr: 'true && false',   expected: false },
   {expr: '1 == "1"',        expected: true  },
   {expr: '2 != "2"',        expected: false },
@@ -66,6 +67,7 @@ const fixtures = [
   {expr: 'foo.bar',      expected: 'baz' }, 
   {expr: 'foo["bar"]',   expected: 'baz' }, 
   {expr: 'foo[foo.bar]', expected: 'wow' },
+  {expr: 'bogus.thing',  expected: undefined },
 
   // unary expression
   {expr: '-one',   expected: -1   },
@@ -113,6 +115,14 @@ fixtures.forEach((o) => {
   var ast = expr.parse( 'this.A' );
   var val = expr.eval.apply( localThis, [ ast, context ] );
   if ( val === 'aay' ) passed++;
+})();
+
+// test the default route
+(function testBogus() {
+  tests++;
+  var ast = { type: "Bogus" };
+  var val = expr.eval( ast, {} );
+  if ( val === undefined ) passed++;
 })();
 
 console.log('%s/%s tests passed.', passed, tests);

--- a/test.js
+++ b/test.js
@@ -65,9 +65,6 @@ const fixtures = [
   {expr: 'foo["bar"]',   expected: 'baz' }, 
   {expr: 'foo[foo.bar]', expected: 'wow' },
 
-  // this expression
-  {expr: 'this.foo', expected: 'bar' },
-
   // unary expression
   {expr: '-one',   expected: -1   },
   {expr: '+two',   expected: 2    },
@@ -88,15 +85,17 @@ const context = {
   numMap: {10: 'ten', 3: 'three'},
   list: [1,2,3,4,5],
   func: function(x) { return x + 1; },
-  this: { foo: 'bar' },
   isArray: Array.isArray,
 
 };
 
+var tests = 0;
 var passed = 0;
 
+
 fixtures.forEach((o) => {
-  let val = expr.compile(o.expr)(context);
+  tests++;
+  var val = expr.compile(o.expr)(context);
   assert.equal(
     val,
     o.expected,
@@ -104,4 +103,15 @@ fixtures.forEach((o) => {
   passed++;
 });
 
-console.log('%s/%s tests passed.', passed, fixtures.length);
+// test 'this'
+(function testThis() {
+  tests++;
+  this.foo = 'bar';
+  var ast = expr.parse( 'this.foo' );
+  var val = expr.eval( ast, { 'baz': 'blah' } );
+  assert.equal( val, 'bar' );
+  passed++;
+})();
+
+
+console.log('%s/%s tests passed.', passed, tests);

--- a/test.js
+++ b/test.js
@@ -2,27 +2,106 @@ const expr = require('./');
 const assert = require('assert');
 
 const fixtures = [
-  {expr: '1 + 2 + 3', expected: 6},
+
+  // array expression
+  {expr: '([1,2,3])[0]',               expected: 1     },
+  {expr: '(["one","two","three"])[1]', expected: "two" },
+  {expr: '([true,false,true])[2]',     expected: true  },
+  {expr: '([1,true,"three"]).length',  expected: 3     },
+  {expr: 'isArray([1,2,3])',           expected: true  },
+  {expr: 'list[3]',                    expected: 4     },
+  {expr: 'numMap[1 + two]',            expected: 'three'},
+  
+  // binary expression
+  {expr: '1+2',         expected: 3},
+  {expr: '2-1',         expected: 1},
+  {expr: '2*2',         expected: 4},
+  {expr: '6/3',         expected: 2},
+  {expr: '5|3',         expected: 7},
+  {expr: '5&3',         expected: 1},
+  {expr: '5^3',         expected: 6},
+  {expr: '4<<2',        expected: 16},
+  {expr: '256>>4',      expected: 16},
+  {expr: '-14>>>2',     expected: 1073741820},
+  {expr: '10%6',        expected: 4},
+  {expr: '"a"+"b"',     expected: "ab"},
   {expr: 'one + three', expected: 4},
-  {expr: 'foo.bar + 2', expected: 'baz2'},
-  {expr: 'foo.bar + 2', expected: 'baz2'},
-  {expr: 'numMap[1 + two]', expected: 'three'},
-  {expr: '"run" + "ning"', expected: 'running'}
+
+  // call expression
+  {expr: 'func(5)',   expected: 6},               
+  {expr: 'func(1+2)', expected: 4},
+
+  // conditional expression
+  {expr: '(true ? "true" : "false")',               expected: "true"  }, 
+  {expr: '( ( bool || false ) ? "true" : "false")', expected: "true"  }, 
+  {expr: '( true ? ( 123*456 ) : "false")',         expected: 123*456 }, 
+  {expr: '( false ? "true" : one + two )',          expected: 3       }, 
+
+  // identifier
+  {expr: 'string', expected: "string" },
+  {expr: 'number', expected: 123      },
+  {expr: 'bool',   expected: true     },
+
+  // literal 
+  {expr: '"foo"', expected: "foo" }, // string literal
+  {expr: "'foo'", expected: "foo" }, // string literal
+  {expr: '123',   expected: 123   }, // numeric literal
+  {expr: 'true',  expected: true  }, // boolean literal
+
+  // logical expression
+  {expr: 'true || false',   expected: true  },
+  {expr: 'true && false',   expected: false },
+  {expr: '1 == "1"',        expected: true  },
+  {expr: '2 != "2"',        expected: false },
+  {expr: '1.234 === 1.234', expected: true  },
+  {expr: '123 !== "123"',   expected: true  },
+  {expr: '1 < 2',           expected: true  },
+  {expr: '1 > 2',           expected: false },
+  {expr: '2 <= 2',          expected: true  },
+  {expr: '1 >= 2',          expected: false },
+
+  // member expression
+  {expr: 'foo.bar',      expected: 'baz' }, 
+  {expr: 'foo["bar"]',   expected: 'baz' }, 
+  {expr: 'foo[foo.bar]', expected: 'wow' },
+
+  // this expression
+  {expr: 'this.foo', expected: 'bar' },
+
+  // unary expression
+  {expr: '-one',   expected: -1   },
+  {expr: '+two',   expected: 2    },
+  {expr: '!false', expected: true },
+  {expr: '!!true', expected: true },
+  {expr: '~15',    expected: -16  },
+
 ];
 
 const context = {
+  string: "string",
+  number: 123,
+  bool: true,
   one: 1,
   two: 2,
   three: 3,
-  foo: {bar: 'baz'},
-  numMap: {10: 'ten', 3: 'three'}
+  foo: {bar: 'baz', baz: "wow"},
+  numMap: {10: 'ten', 3: 'three'},
+  list: [1,2,3,4,5],
+  func: function(x) { return x + 1; },
+  this: { foo: 'bar' },
+  isArray: Array.isArray,
+
 };
 
+var passed = 0;
+
 fixtures.forEach((o) => {
+  let val = expr.compile(o.expr)(context);
   assert.equal(
-    expr.compile(o.expr)(context),
+    val,
     o.expected,
-    'Failed: ' + o.expr + ' === ' + o.expected);
+    'Failed: ' + o.expr + ' ('+val+') === ' + o.expected);
+  passed++;
 });
 
-console.log('%s/%s tests passed.', fixtures.length, fixtures.length);
+console.log('%s/%s tests passed.', passed, fixtures.length);

--- a/test.js
+++ b/test.js
@@ -76,6 +76,9 @@ const fixtures = [
   {expr: '!!true', expected: true },
   {expr: '~15',    expected: -16  },
 
+  // member functions
+  {expr: '("foo").substr(0,1)', expected: 'f'},
+
 ];
 
 const context = {

--- a/test.js
+++ b/test.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const expr = require('./');
 const assert = require('assert');
 
@@ -106,12 +108,11 @@ fixtures.forEach((o) => {
 // test 'this'
 (function testThis() {
   tests++;
-  this.foo = 'bar';
-  var ast = expr.parse( 'this.foo' );
-  var val = expr.eval( ast, { 'baz': 'blah' } );
-  assert.equal( val, 'bar' );
-  passed++;
+  var localThis = { A: 'aay', B: 'bee' };
+  var context = { baz: 'blah' };
+  var ast = expr.parse( 'this.A' );
+  var val = expr.eval.apply( localThis, [ ast, context ] );
+  if ( val === 'aay' ) passed++;
 })();
-
 
 console.log('%s/%s tests passed.', passed, tests);


### PR DESCRIPTION
Current code for method calls only works if the method is directly defined on the object, and then does not call it with the appropriate `this` value.  Added support for looking up the prototype chain to find the method and call it on the appropriate object.  Allows expressions like `('foo').substr(0,1) == 'f'`