### PR TITLE
Make expression-eval es5 compatible

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ var unops = {
 };
 
 function evaluateArray ( list, context ) {
-  return list.map((v) => evaluate(v, context));
+  return list.map(function (v) { return evaluate(v, context); });
 }
 
 function evaluateMember ( node, context ) {


### PR DESCRIPTION
importing this in webpack and then using it in IE11 breaks it with compilation errors