### PR TITLE
feat(async): add evalAsync compileAsync

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,8 @@
 import * as jsep from "jsep";
 
 declare function compile(expression: string | jsep.Expression): (context: object) => any;
+declare function compileAsync(expression: string | jsep.Expression): (context: object) => Promise<any>;
 declare function evaluate(node: jsep.Expression, context: object): any;
+declare function evaluateAsync(node: jsep.Expression, context: object): Promise<any>;
 
-export { compile, jsep as parse, evaluate as eval };
+export { compile, compileAsync, jsep as parse, evaluate as eval, evaluateAsync as evalAsync };

--- a/test.js
+++ b/test.js
@@ -116,4 +116,37 @@ fixtures.forEach((o) => {
   passed++;
 });
 
-console.log('%s/%s tests passed.', passed, tests);
+async function testAsync() {
+  const asyncContext = context;
+  asyncContext.asyncFunc = async function(a, b) {
+    return await a + b;
+  };
+  asyncContext.promiseFunc = function(a, b) {
+    return new Promise((resolve, reject) => {
+      setTimeout(() => resolve(a + b), 1000);
+    })
+  }
+  const asyncFixtures = fixtures;
+  asyncFixtures.push({
+    expr: 'asyncFunc(one, two)',
+    expected: 3,
+  }, {
+    expr: 'promiseFunc(one, two)',
+    expected: 3,
+  });
+  for (let o of asyncFixtures) {
+    tests++;
+    try {
+      var val = await expr.compileAsync(o.expr)(asyncContext);
+    } catch (e) {
+      console.error(`Error: ${o.expr}, expected ${o.expected}`);
+      throw e;
+    }
+    assert.equal(val, o.expected, `Failed: ${o.expr} (${val}) === ${o.expected}`);
+    passed++;
+  }
+}
+
+testAsync().then(() => {
+  console.log('%s/%s tests passed.', passed, tests);
+})


### PR DESCRIPTION
It would be better if we can use async function or Promise in the expression context, we want promise automatically resolved when the expression evaluated.

demo code:
```JavaScript
const expressionStr = `g(a, b)`;
const context = {
 g: async function(a, b) {
    // do something async
      return something
  },
  a: 'host',
  b: 'port'
}
```

So I add `evalAsync` and `compileAsync` to support this usecase.

