### PR TITLE
Fix bug with unary plus

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ const binops = {
 
 const unops = {
   '-' :  function (a) { return -a; },
-  '+' :  function (a) { return a; },
+  '+' :  function (a) { return +a; },
   '~' :  function (a) { return ~a; },
   '!' :  function (a) { return !a; },
 };

--- a/test.js
+++ b/test.js
@@ -80,6 +80,7 @@ const fixtures = [
   {expr: '!false', expected: true },
   {expr: '!!true', expected: true },
   {expr: '~15',    expected: -16  },
+  {expr: '+[]',    expected: 0    },
 
   // 'this' context
   {expr: 'this.three', expected: 3 },


### PR DESCRIPTION
There is a problem with converting array: `+[]` must return `0`