### PR TITLE
Fix typescript export of jsep

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-import * as jsep from 'jsep';
+import jsep from 'jsep';
 
 declare type operand = number | string;
 declare type unaryCallback = (a: operand) => operand;


### PR DESCRIPTION
Hello!  In using this module from a Typescript project, the following code results in a Typescript error:

```
import { eval, parse } from "expression-eval";

const expression = 'whatever';
const ast = parse(expression);
```
Error:
>  This expression is not callable.   Type 'typeof jsep' has no call signatures

This PR fixes the import to match what's in [`index.js`](https://github.com/donmccurdy/expression-eval/blob/master/index.js#L1), which resolves the issue for me.  