### PR TITLE
Adds options object, implements option implicitOptionalChaining, tests...

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -89,7 +89,7 @@ function evaluate(_node: jsep.Expression, context: object, options: EvaluateOpti
   function evaluateMember(node: jsep.MemberExpression) {
     const object = evaluateNode(node.object);
     if (node.computed) {
-      return [object, object[evaluateNode(node.property)]];
+      return [object, options.implicitOptionalChaining ? object?.[evaluateNode(node.property)] : object[evaluateNode(node.property)]]
     } else {
       const name = (node.property as jsep.Identifier).name;
       return [object, options.implicitOptionalChaining ? object?.[name] : object[name]]
@@ -166,7 +166,7 @@ async function evalAsync(_node: jsep.Expression, context: object, options: Evalu
   async function evaluateMemberAsync(node: jsep.MemberExpression) {
     const object = await evalAsyncNode(node.object);
     if (node.computed) {
-      return [object, object[await evalAsyncNode(node.property)]];
+      return [object, options.implicitOptionalChaining ? object?.[await evalAsyncNode(node.property)] : object[await evalAsyncNode(node.property)]]
     } else {
       const name = (node.property as jsep.Identifier).name;
       return [object, options.implicitOptionalChaining ? object?.[name] : object[name]]

--- a/index.ts
+++ b/index.ts
@@ -258,11 +258,11 @@ async function evalAsync(_node: jsep.Expression, context: object, options: Evalu
   return evalAsyncNode(_node);
 }
 
-function compile(expression: string | jsep.Expression): (context: object) => any {
+function compile(expression: string | jsep.Expression): (context: object, options: EvaluateOptions) => any {
   return evaluate.bind(null, jsep(expression));
 }
 
-function compileAsync(expression: string | jsep.Expression): (context: object) => Promise<any> {
+function compileAsync(expression: string | jsep.Expression): (context: object, options: EvaluateOptions) => Promise<any> {
   return evalAsync.bind(null, jsep(expression));
 }
 

--- a/index.ts
+++ b/index.ts
@@ -76,172 +76,186 @@ type AnyExpression = jsep.ArrayExpression
   | jsep.ThisExpression
   | jsep.UnaryExpression;
 
-function evaluateArray(list, context) {
-  return list.map(function (v) { return evaluate(v, context); });
+declare interface EvaluateOptions {
+  implicitOptionalChaining?: boolean;
 }
 
-async function evaluateArrayAsync(list, context) {
-  const res = await Promise.all(list.map((v) => evalAsync(v, context)));
-  return res;
-}
+function evaluate(_node: jsep.Expression, context: object, options: EvaluateOptions = {}) {
 
-function evaluateMember(node: jsep.MemberExpression, context: object) {
-  const object = evaluate(node.object, context);
-  if (node.computed) {
-    return [object, object[evaluate(node.property, context)]];
-  } else {
-    return [object, object[(node.property as jsep.Identifier).name]];
-  }
-}
-
-async function evaluateMemberAsync(node: jsep.MemberExpression, context: object) {
-  const object = await evalAsync(node.object, context);
-  if (node.computed) {
-    return [object, object[await evalAsync(node.property, context)]];
-  } else {
-    return [object, object[(node.property as jsep.Identifier).name]];
-  }
-}
-
-function evaluate(_node: jsep.Expression, context: object) {
-
-  const node = _node as AnyExpression;
-
-  switch (node.type) {
-
-    case 'ArrayExpression':
-      return evaluateArray(node.elements, context);
-
-    case 'BinaryExpression':
-      return binops[node.operator](evaluate(node.left, context), evaluate(node.right, context));
-
-    case 'CallExpression':
-      let caller, fn, assign;
-      if (node.callee.type === 'MemberExpression') {
-        assign = evaluateMember(node.callee as jsep.MemberExpression, context);
-        caller = assign[0];
-        fn = assign[1];
-      } else {
-        fn = evaluate(node.callee, context);
-      }
-      if (typeof fn !== 'function') { return undefined; }
-      return fn.apply(caller, evaluateArray(node.arguments, context));
-
-    case 'ConditionalExpression':
-      return evaluate(node.test, context)
-        ? evaluate(node.consequent, context)
-        : evaluate(node.alternate, context);
-
-    case 'Identifier':
-      return context[node.name];
-
-    case 'Literal':
-      return node.value;
-
-    case 'LogicalExpression':
-      if (node.operator === '||') {
-        return evaluate(node.left, context) || evaluate(node.right, context);
-      } else if (node.operator === '&&') {
-        return evaluate(node.left, context) && evaluate(node.right, context);
-      }
-      return binops[node.operator](evaluate(node.left, context), evaluate(node.right, context));
-
-    case 'MemberExpression':
-      return evaluateMember(node, context)[1];
-
-    case 'ThisExpression':
-      return context;
-
-    case 'UnaryExpression':
-      return unops[node.operator](evaluate(node.argument, context));
-
-    default:
-      return undefined;
+  function evaluateArray(list) {
+    return list.map(function (v) { return evaluateNode(v); });
   }
 
-}
-
-async function evalAsync(_node: jsep.Expression, context: object) {
-
-  const node = _node as AnyExpression;
-
-  // Brackets used for some case blocks here, to avoid edge cases related to variable hoisting.
-  // See: https://stackoverflow.com/questions/57759348/const-and-let-variable-shadowing-in-a-switch-statement
-  switch (node.type) {
-
-    case 'ArrayExpression':
-      return await evaluateArrayAsync(node.elements, context);
-
-    case 'BinaryExpression': {
-      const [left, right] = await Promise.all([
-        evalAsync(node.left, context),
-        evalAsync(node.right, context)
-      ]);
-      return binops[node.operator](left, right);
+  function evaluateMember(node: jsep.MemberExpression) {
+    const object = evaluateNode(node.object);
+    if (node.computed) {
+      return [object, object[evaluateNode(node.property)]];
+    } else {
+      const name = (node.property as jsep.Identifier).name;
+      return [object, options.implicitOptionalChaining ? object?.[name] : object[name]]
     }
+  }
 
-    case 'CallExpression': {
-      let caller, fn, assign;
-      if (node.callee.type === 'MemberExpression') {
-        assign = await evaluateMemberAsync(node.callee as jsep.MemberExpression, context);
-        caller = assign[0];
-        fn = assign[1];
-      } else {
-        fn = await evalAsync(node.callee, context);
-      }
-      if (typeof fn !== 'function') {
+  function evaluateNode(_jsepNode: jsep.Expression) {
+
+    const node = _jsepNode as AnyExpression;
+
+    switch (node.type) {
+
+      case 'ArrayExpression':
+        return evaluateArray(node.elements);
+
+      case 'BinaryExpression':
+        return binops[node.operator](evaluateNode(node.left), evaluateNode(node.right));
+
+      case 'CallExpression':
+        let caller, fn, assign;
+        if (node.callee.type === 'MemberExpression') {
+          assign = evaluateMember(node.callee as jsep.MemberExpression);
+          caller = assign[0];
+          fn = assign[1];
+        } else {
+          fn = evaluateNode(node.callee);
+        }
+        if (typeof fn !== 'function') { return undefined; }
+        return fn.apply(caller, evaluateArray(node.arguments));
+
+      case 'ConditionalExpression':
+        return evaluateNode(node.test)
+          ? evaluateNode(node.consequent)
+          : evaluateNode(node.alternate);
+
+      case 'Identifier':
+        return context[node.name];
+
+      case 'Literal':
+        return node.value;
+
+      case 'LogicalExpression':
+        if (node.operator === '||') {
+          return evaluateNode(node.left) || evaluateNode(node.right);
+        } else if (node.operator === '&&') {
+          return evaluateNode(node.left) && evaluateNode(node.right);
+        }
+        return binops[node.operator](evaluateNode(node.left), evaluateNode(node.right));
+
+      case 'MemberExpression':
+        return evaluateMember(node)[1];
+
+      case 'ThisExpression':
+        return context;
+
+      case 'UnaryExpression':
+        return unops[node.operator](evaluateNode(node.argument));
+
+      default:
         return undefined;
-      }
-      return await fn.apply(
-        caller,
-        await evaluateArrayAsync(node.arguments, context)
-      );
     }
-
-    case 'ConditionalExpression':
-      return (await evalAsync(node.test, context))
-        ? await evalAsync(node.consequent, context)
-        : await evalAsync(node.alternate, context);
-
-    case 'Identifier':
-      return context[node.name];
-
-    case 'Literal':
-      return node.value;
-
-    case 'LogicalExpression': {
-      if (node.operator === '||') {
-        return (
-          (await evalAsync(node.left, context)) ||
-          (await evalAsync(node.right, context))
-        );
-      } else if (node.operator === '&&') {
-        return (
-          (await evalAsync(node.left, context)) &&
-          (await evalAsync(node.right, context))
-        );
-      }
-
-      const [left, right] = await Promise.all([
-        evalAsync(node.left, context),
-        evalAsync(node.right, context)
-      ]);
-
-      return binops[node.operator](left, right);
-    }
-
-    case 'MemberExpression':
-      return (await evaluateMemberAsync(node, context))[1];
-
-    case 'ThisExpression':
-      return context;
-
-    case 'UnaryExpression':
-      return unops[node.operator](await evalAsync(node.argument, context));
-
-    default:
-      return undefined;
   }
+
+  return evaluateNode(_node);
+}
+
+async function evalAsync(_node: jsep.Expression, context: object, options: EvaluateOptions = {}) {
+
+  async function evaluateArrayAsync(list) {
+    const res = await Promise.all(list.map((v) => evalAsyncNode(v)));
+    return res;
+  }
+
+  async function evaluateMemberAsync(node: jsep.MemberExpression) {
+    const object = await evalAsyncNode(node.object);
+    if (node.computed) {
+      return [object, object[await evalAsyncNode(node.property)]];
+    } else {
+      const name = (node.property as jsep.Identifier).name;
+      return [object, options.implicitOptionalChaining ? object?.[name] : object[name]]
+    }
+  }
+
+  async function evalAsyncNode(jsepNode: jsep.Expression) {
+    const node = jsepNode as AnyExpression;
+
+    // Brackets used for some case blocks here, to avoid edge cases related to variable hoisting.
+    // See: https://stackoverflow.com/questions/57759348/const-and-let-variable-shadowing-in-a-switch-statement
+    switch (node.type) {
+
+      case 'ArrayExpression':
+        return await evaluateArrayAsync(node.elements);
+
+      case 'BinaryExpression': {
+        const [left, right] = await Promise.all([
+          evalAsyncNode(node.left),
+          evalAsyncNode(node.right)
+        ]);
+        return binops[node.operator](left, right);
+      }
+
+      case 'CallExpression': {
+        let caller, fn, assign;
+        if (node.callee.type === 'MemberExpression') {
+          assign = await evaluateMemberAsync(node.callee as jsep.MemberExpression);
+          caller = assign[0];
+          fn = assign[1];
+        } else {
+          fn = await evalAsyncNode(node.callee);
+        }
+        if (typeof fn !== 'function') {
+          return undefined;
+        }
+        return await fn.apply(
+          caller,
+          await evaluateArrayAsync(node.arguments)
+        );
+      }
+
+      case 'ConditionalExpression':
+        return (await evalAsyncNode(node.test))
+          ? await evalAsyncNode(node.consequent)
+          : await evalAsyncNode(node.alternate);
+
+      case 'Identifier':
+        return context[node.name];
+
+      case 'Literal':
+        return node.value;
+
+      case 'LogicalExpression': {
+        if (node.operator === '||') {
+          return (
+            (await evalAsyncNode(node.left)) ||
+            (await evalAsyncNode(node.right))
+          );
+        } else if (node.operator === '&&') {
+          return (
+            (await evalAsyncNode(node.left)) &&
+            (await evalAsyncNode(node.right))
+          );
+        }
+
+        const [left, right] = await Promise.all([
+          evalAsyncNode(node.left),
+          evalAsyncNode(node.right)
+        ]);
+
+        return binops[node.operator](left, right);
+      }
+
+      case 'MemberExpression':
+        return (await evaluateMemberAsync(node))[1];
+
+      case 'ThisExpression':
+        return context;
+
+      case 'UnaryExpression':
+        return unops[node.operator](await evalAsyncNode(node.argument));
+
+      default:
+        return undefined;
+    }
+  }
+
+  return evalAsyncNode(_node);
 }
 
 function compile(expression: string | jsep.Expression): (context: object) => any {

--- a/test.js
+++ b/test.js
@@ -95,7 +95,9 @@ const fixtures = [
 
   // implicit optional chaining
   {expr: 'foo.not.here', expected: undefined, options: {implicitOptionalChaining: true}},
-  {expr: 'foo.not.here', throws: /Cannot read property 'here' of undefined/}
+  {expr: 'foo.not.here', throws: /Cannot read property 'here' of undefined/},
+  {expr: 'foo.not[0].here', expected: undefined, options: {implicitOptionalChaining: true}},
+  {expr: 'foo.not[0].here', throws: /Cannot read property '0' of undefined/}
 ];
 
 const context = {


### PR DESCRIPTION
I needed some functionality to evaluate expressions against an unknown context of query results. As such I have no guarantee that `results.foo` and `results.foo.bar` exist when I try to access them to determine whether my step will run. Catching thrown errors is not sufficient either, as an expression might evaluate against many results, which may or may-not exist, e.g., `results.foo.bar == true || results.baz.bar == true`. 

This PR adds an optional behavior to use an optional-chain when evaluating the object member expressions when the `implicitOptionalChaining` option is set to true. It also adds in support for options, and restructures the functions to do that in a more convenient way (similar to this PR https://github.com/donmccurdy/expression-eval/pull/42). 

I also added some tests that validate the new behavior and ensure the old `throw` behavior still works.

